### PR TITLE
Show url as well, needs Lastpass CLI 1.2.2

### DIFF
--- a/i3-lastpass
+++ b/i3-lastpass
@@ -3,10 +3,10 @@
 set -euf -o pipefail
 
 # Try fetch the list without syncing, but sync if lpass-cli doesnt have the blob cached
-LPASS_ITEMS=$(lpass ls --sync=no --color=never --format="%aN (%au) | %ai" || printf 'no-sync')
+LPASS_ITEMS=$(lpass ls --sync=no --color=never --format="%aN (%au) (%al) | %ai" || printf 'no-sync')
 if [[ "${LPASS_ITEMS}" == "no-sync" ]]
 then
-  LPASS_ITEMS=$(lpass ls --sync=auto --color=never --format="%aN (%au) | %ai" || printf "no-sync")
+  LPASS_ITEMS=$(lpass ls --sync=auto --color=never --format="%aN (%au) (%al) | %ai" || printf "no-sync")
   if [[ "${LPASS_ITEMS}" == "no-sync" ]]
   then
     printf "You need to login to LastPass first: (lpass login --trust <username>)\n" | dmenu -p "LastPass"

--- a/i3-lastpass
+++ b/i3-lastpass
@@ -14,7 +14,7 @@ then
   fi
 fi
 
-LPASS_SELECTION=$(printf "${LPASS_ITEMS}" | dmenu -p "LastPass" -i -l 3)
+LPASS_SELECTION=$(echo "${LPASS_ITEMS}" | dmenu -p "LastPass" -i -l 3)
 LPASS_SELECTION_ID=$(echo "${LPASS_SELECTION}" | sed 's/.*| //' | xargs)
 
 lpass show --sync=no --password "${LPASS_SELECTION_ID}" | xsel --secondary -i


### PR DESCRIPTION
Lastpass CLI 1.2.2 (https://github.com/lastpass/lastpass-cli/releases/tag/v1.2.2) now supports showing the URL with the format command. This makes searching by URL possible as well